### PR TITLE
Moves requests to BedSleepManager, Adds PlayerQuitEvent Check, Removes One Person Loophole, Sleep Voting Enabled by BedEnter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
-#minewestcore 
+# minewestcore 
+    

--- a/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
+++ b/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
@@ -39,7 +39,7 @@ public class MinewestCorePlugin extends JavaPlugin {
 
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, new Runnable() {
             public void run() {
-                manager.resetRequests();
+                manager.setEnabled(false);
             }
         }, timeUntilMorning, DAY_LENGTH);
     }

--- a/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
+++ b/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
@@ -11,6 +11,19 @@ public class MinewestCorePlugin extends JavaPlugin {
     private static MinewestCorePlugin instance;
     private BedSleepManager manager;
 
+
+    // See https://minecraft.gamepedia.com/Day-night_cycle
+    public static final int DAY_LENGTH = 24000;
+
+    // Time when using the `/time set day` command.
+    public static final int MORNING_START = 1000;
+
+    // 12542: In clear weather, beds can be used at this point.
+    public static final int BED_START = 12542;
+
+    // 23460: In clear weather, beds can no longer be used.
+    public static final int BED_END = 23460;
+
     @Override
     public void onEnable() {
         instance = this;
@@ -21,15 +34,14 @@ public class MinewestCorePlugin extends JavaPlugin {
 
         Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
 
-        // Every 30 seconds, if it is day, reset the bed information
+        long currentTime = Bukkit.getWorld("world").getTime();
+        long timeUntilMorning = (DAY_LENGTH + MORNING_START - currentTime) % DAY_LENGTH;
+
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, new Runnable() {
             public void run() {
-                if (manager.isDay(getServer().getWorld("world"))) {
-                    SleepCommand.clearPlayers();
-                    manager.resetSleepRequests();
-                }
+                manager.resetRequests();
             }
-        }, 0, 600);
+        }, timeUntilMorning, DAY_LENGTH);
     }
 
     public static MinewestCorePlugin getInstance() {

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 public class BedSleepManager {
 
     private static final float REQUIRED_PLAYER_RATIO = 0.5f;
+    private static final int MINIMUM_ABSOLUTE_REQUESTS = 1;
 
     private Map<UUID, Boolean> requests = new HashMap<UUID, Boolean>();
 
@@ -45,18 +46,8 @@ public class BedSleepManager {
     }
 
     public int getNeededRequests() {
-
-        if (Bukkit.getOnlinePlayers().size() == 1) {
-            return 1;
-        }
-
         int needed = (int) (REQUIRED_PLAYER_RATIO * getValidPlayers());
-
-        if (needed == 0) {
-            return 1;
-        }
-
-        return needed;
+        return Math.max(needed, MINIMUM_ABSOLUTE_REQUESTS);
     }
 
     private int getValidPlayers() {

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -16,10 +16,20 @@ public class BedSleepManager {
     private static final int MINIMUM_ABSOLUTE_REQUESTS = 1;
 
     private Map<UUID, Boolean> requests = new HashMap<UUID, Boolean>();
+    private boolean sleepingEnabled = false;
+
+    public void setEnabled(boolean enabled) {
+        sleepingEnabled = enabled;
+        if (!enabled) {
+            resetRequests();
+        }
+    }
 
     public void castVote(UUID player, boolean accept) {
-        requests.put(player, accept);
-        checkRequired();
+        if (sleepingEnabled) {
+            requests.put(player, accept);
+            checkRequired();
+        }
     }
 
     public boolean hasVoted(UUID player) {
@@ -31,6 +41,10 @@ public class BedSleepManager {
         checkRequired();
     }
 
+    private void resetRequests() {
+        requests.clear();
+    }
+
     public int getRequests() {
         int acceptances = 0;
         for (UUID player : requests.keySet()) {
@@ -39,10 +53,6 @@ public class BedSleepManager {
             }
         }
         return acceptances;
-    }
-
-    public void resetRequests() {
-        requests.clear();
     }
 
     public int getNeededRequests() {

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -64,7 +64,7 @@ public class BedSleepManager {
 
         for (World world : Bukkit.getWorlds()) {
             if (!isDay(world)) {
-                world.setTime(1000);
+                world.setTime(MinewestCorePlugin.MORNING_START);
             }
 
             if (isThundering(world)) {
@@ -84,7 +84,7 @@ public class BedSleepManager {
 
         long time = world.getTime();
 
-        return time < 12541 || time > 23458;
+        return time < MinewestCorePlugin.BED_START || time >= MinewestCorePlugin.BED_END;
     }
 
     public boolean isThundering(World world) {

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -17,6 +17,10 @@ public class SleepCommand implements CommandExecutor {
     }
 
     public boolean onCommand(final CommandSender commandSender, Command command, String s, String[] args) {
+        if (!(commandSender instanceof Player)) {
+            return false;
+        }
+
         final Player player = (Player) commandSender;
 
         if (args.length != 1) {

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -1,6 +1,5 @@
 package net.minewest.minewestcore.bedutil.commands;
 
-import net.minewest.minewestcore.MinewestCorePlugin;
 import net.minewest.minewestcore.bedutil.BedSleepManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -9,15 +8,9 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-
 public class SleepCommand implements CommandExecutor {
 
     private BedSleepManager manager;
-    private static Set<UUID> players = new HashSet<UUID>();
 
     public SleepCommand(BedSleepManager manager) {
         this.manager = manager;
@@ -51,36 +44,23 @@ public class SleepCommand implements CommandExecutor {
             }
         }
 
-        if (players.contains(player.getUniqueId())) {
+        if (manager.hasVoted(player.getUniqueId())) {
             commandSender.sendMessage(ChatColor.RED + "You have already selected an option!");
             return true;
         }
 
+        manager.castVote(player.getUniqueId(), accept);
         if (accept) {
-            manager.increaseSleepRequest();
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     manager.getNeededRequests() + " " + ChatColor.GREEN + commandSender.getName() + " has accepted.");
         } else {
-            manager.decreaseSleepRequest();
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     manager.getNeededRequests() + " " + ChatColor.RED + commandSender.getName() + " has denied.");
         }
-
-        players.add(player.getUniqueId());
-        manager.checkRequired();
-
         return true;
     }
 
     private static void sendUsage(final CommandSender commandSender) {
         commandSender.sendMessage(ChatColor.WHITE + "Usage: " + ChatColor.RED + "/sleep [accept/deny]");
-    }
-
-    public static Collection<UUID> getPlayers() {
-        return players;
-    }
-
-    public static void clearPlayers() {
-        players.clear();
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerBedEnterEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
 
@@ -42,5 +43,10 @@ public class PlayerListener implements Listener {
         if (!MinewestCorePlugin.getInstance().getBedSleepManager().hasVoted(event.getPlayer().getUniqueId())) {
             event.getPlayer().performCommand("sleep accept");
         }
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        MinewestCorePlugin.getInstance().getBedSleepManager().removePlayer(event.getPlayer().getUniqueId());
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
@@ -3,7 +3,7 @@ package net.minewest.minewestcore.bedutil.listeners;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.minewest.minewestcore.bedutil.commands.SleepCommand;
+import net.minewest.minewestcore.MinewestCorePlugin;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -39,7 +39,7 @@ public class PlayerListener implements Listener {
             player.spigot().sendMessage(c);
         }
 
-        if (!SleepCommand.getPlayers().contains(event.getPlayer().getUniqueId())) {
+        if (!MinewestCorePlugin.getInstance().getBedSleepManager().hasVoted(event.getPlayer().getUniqueId())) {
             event.getPlayer().performCommand("sleep accept");
         }
     }

--- a/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
@@ -4,6 +4,7 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
 import net.minewest.minewestcore.MinewestCorePlugin;
+import net.minewest.minewestcore.bedutil.BedSleepManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -40,9 +41,10 @@ public class PlayerListener implements Listener {
             player.spigot().sendMessage(c);
         }
 
-        if (!MinewestCorePlugin.getInstance().getBedSleepManager().hasVoted(event.getPlayer().getUniqueId())) {
-            event.getPlayer().performCommand("sleep accept");
-        }
+        BedSleepManager manager = MinewestCorePlugin.getInstance().getBedSleepManager();
+
+        manager.setEnabled(true);
+        event.getPlayer().performCommand("sleep accept");
     }
 
     @EventHandler

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: MinewestCore
 main: net.minewest.minewestcore.MinewestCorePlugin
-author: Taon2
-version: 1.0.3
+authors: [Taon2, spencrr]
+version: 1.0.4
 commands:
   sleep:
     description: Accepts or denies a request to sleep.
-    usage: /sleep {accept/deny}
+    usage: /sleep [accept|deny]


### PR DESCRIPTION
- Requests are now handled in the BedSleepManager by a HashMap and the total requests are summed by iterating over the map
- When a player quits, the BedSleepManager.removePlayer() is called, in turn calling the checkRequired()
- Whenever a player successfully casts a vote (as defined in the SleepCommand as not having already voted), checkRequired() is called automatically
- If only one person is online, they will be required to be in the Overworld to successfully trigger the sleep command
- Enables bed sleeping after player enters bed and disables in morning
- Constants extracting magic numbers