### PR TITLE
Contains checkRequired functionality in BedSleepManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.minewest</groupId>
     <artifactId>MinewestCore</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -108,6 +108,7 @@ public class BedSleepManager {
     public void castVote(UUID player, boolean accept) {
         if (getEnabled()) {
             requests.put(player, accept);
+            checkRequired();
         }
     }
 
@@ -144,7 +145,7 @@ public class BedSleepManager {
         return acceptances;
     }
 
-    public void checkRequired() {
+    private void checkRequired() {
         if (!getEnabled() || getRequests() < getNeededRequests()) {
             return;
         }

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -62,7 +62,6 @@ public class SleepCommand implements CommandExecutor {
             return true;
         }
 
-        manager.castVote(player.getUniqueId(), accept);
         if (accept) {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.GREEN + commandSender.getName() + " has accepted.");
@@ -70,8 +69,8 @@ public class SleepCommand implements CommandExecutor {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.RED + commandSender.getName() + " has denied.");
         }
+        manager.castVote(player.getUniqueId(), accept);
 
-        manager.checkRequired();
         return true;
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -16,10 +16,6 @@ public class SleepCommand implements CommandExecutor {
         this.manager = manager;
     }
 
-    private static void sendUsage(final CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.WHITE + "Usage: " + ChatColor.RED + "/sleep [accept/deny]");
-    }
-
     public boolean onCommand(final CommandSender commandSender, Command command, String s, String[] args) {
         if (!(commandSender instanceof Player)) {
             return false;
@@ -28,7 +24,6 @@ public class SleepCommand implements CommandExecutor {
         final Player player = (Player) commandSender;
 
         if (args.length != 1) {
-            sendUsage(commandSender);
             return false;
         }
 
@@ -36,7 +31,6 @@ public class SleepCommand implements CommandExecutor {
         boolean deny = args[0].equals("deny");
 
         if (!accept && !deny) {
-            sendUsage(commandSender);
             return false;
         }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MinewestCore
 main: net.minewest.minewestcore.MinewestCorePlugin
 authors: [Taon2, spencrr]
-version: 1.0.6
+version: 1.0.7
 commands:
   sleep:
     description: Accepts or denies a request to sleep.


### PR DESCRIPTION
`checkRequired` should stay private, as the only way the `checkRequired` should ever have to run is after an `updatePlayers` or `castVote` is called, thus decreasing potential bugs where a vote is cast but the sleeping requirement is not checked.