### PR TITLE
Refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,19 +15,9 @@
         </repository>
     </repositories>
     <dependencies>
-        <!--Spigot API-->
-        <!--You only need one of the two, don't put both. Spigot is recommended.-->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
-        <!--Bukkit API-->
-        <!--You only need one of the two, don't put both. Spigot is recommended.-->
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
             <version>1.15.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.minewest</groupId>
     <artifactId>MinewestCore</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.minewest</groupId>
     <artifactId>MinewestCore</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.8-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
+++ b/src/main/java/net/minewest/minewestcore/MinewestCorePlugin.java
@@ -8,26 +8,15 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class MinewestCorePlugin extends JavaPlugin {
 
-    private static MinewestCorePlugin instance;
     private BedSleepManager manager;
 
     @Override
     public void onEnable() {
-        instance = this;
-
-        manager = new BedSleepManager();
+        manager = new BedSleepManager(this);
 
         this.getCommand("sleep").setExecutor(new SleepCommand(manager));
 
-        Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
-    }
-
-    public static MinewestCorePlugin getInstance() {
-        return instance;
-    }
-
-    public BedSleepManager getBedSleepManager() {
-        return manager;
+        Bukkit.getPluginManager().registerEvents(new PlayerListener(manager), this);
     }
 
     @Override

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -2,7 +2,6 @@ package net.minewest.minewestcore.bedutil;
 
 import net.minewest.minewestcore.MinewestCorePlugin;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
@@ -111,10 +110,12 @@ public class BedSleepManager {
         }
     }
 
-    public void castVote(UUID player, boolean accept) {
+    public boolean castVote(UUID player, boolean accept) {
         if (getEnabled()) {
             requests.put(player, accept);
+            return checkRequired();
         }
+        return false;
     }
 
     public boolean hasVoted(UUID player) {
@@ -150,9 +151,9 @@ public class BedSleepManager {
         return acceptances;
     }
 
-    public void checkRequired() {
+    private boolean checkRequired() {
         if (!getEnabled() || getRequests() < getNeededRequests()) {
-            return;
+            return false;
         }
 
 
@@ -167,8 +168,8 @@ public class BedSleepManager {
             }
         }
 
-        Bukkit.broadcastMessage(ChatColor.GOLD + "Requests met!");
         resetRequests();
         cancelDisable();
+        return true;
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -7,11 +7,7 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.UUID;
+import java.util.*;
 
 public class BedSleepManager {
 
@@ -31,6 +27,12 @@ public class BedSleepManager {
     private Set<UUID> sleepingPlayers = new HashSet<UUID>();
 
     private BukkitTask morningDisableTask;
+
+    private MinewestCorePlugin plugin;
+
+    public BedSleepManager(MinewestCorePlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public static boolean isDay(World world) {
         if (world == null) {
@@ -79,7 +81,7 @@ public class BedSleepManager {
 
         cancelDisable();
 
-        morningDisableTask = Bukkit.getScheduler().runTaskTimerAsynchronously(MinewestCorePlugin.getInstance(), new Runnable() {
+        morningDisableTask = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, new Runnable() {
             public void run() {
                 resetRequests();
             }

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -7,7 +7,11 @@ import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class BedSleepManager {
 

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -110,7 +110,6 @@ public class BedSleepManager {
     public void castVote(UUID player, boolean accept) {
         if (getEnabled()) {
             requests.put(player, accept);
-            checkRequired();
         }
     }
 
@@ -147,7 +146,7 @@ public class BedSleepManager {
         return acceptances;
     }
 
-    private void checkRequired() {
+    public void checkRequired() {
         if (!getEnabled() || getRequests() < getNeededRequests()) {
             return;
         }

--- a/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/BedSleepManager.java
@@ -108,6 +108,7 @@ public class BedSleepManager {
     public void castVote(UUID player, boolean accept) {
         if (getEnabled()) {
             requests.put(player, accept);
+            checkRequired();
         }
     }
 
@@ -144,7 +145,7 @@ public class BedSleepManager {
         return acceptances;
     }
 
-    public void checkRequired() {
+    private void checkRequired() {
         if (!getEnabled() || getRequests() < getNeededRequests()) {
             return;
         }

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -56,6 +56,7 @@ public class SleepCommand implements CommandExecutor {
             return true;
         }
 
+        manager.castVote(player.getUniqueId(), accept);
         if (accept) {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.GREEN + commandSender.getName() + " has accepted.");
@@ -63,8 +64,8 @@ public class SleepCommand implements CommandExecutor {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.RED + commandSender.getName() + " has denied.");
         }
-        manager.castVote(player.getUniqueId(), accept);
 
+        manager.checkRequired();
         return true;
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -62,7 +62,6 @@ public class SleepCommand implements CommandExecutor {
             return true;
         }
 
-        manager.castVote(player.getUniqueId(), accept);
         if (accept) {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.GREEN + commandSender.getName() + " has accepted.");
@@ -70,8 +69,8 @@ public class SleepCommand implements CommandExecutor {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.RED + commandSender.getName() + " has denied.");
         }
+        manager.castVote(player.getUniqueId(), accept);
 
-        manager.checkRequired();
         return true;
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -16,10 +16,6 @@ public class SleepCommand implements CommandExecutor {
         this.manager = manager;
     }
 
-    private static void sendUsage(final CommandSender commandSender) {
-        commandSender.sendMessage(ChatColor.WHITE + "Usage: " + ChatColor.RED + "/sleep [accept/deny]");
-    }
-
     public boolean onCommand(final CommandSender commandSender, Command command, String s, String[] args) {
         if (!(commandSender instanceof Player)) {
             return false;
@@ -28,7 +24,6 @@ public class SleepCommand implements CommandExecutor {
         final Player player = (Player) commandSender;
 
         if (args.length != 1) {
-            sendUsage(commandSender);
             return false;
         }
 
@@ -36,7 +31,6 @@ public class SleepCommand implements CommandExecutor {
         boolean deny = args[0].equals("deny");
 
         if (!accept && !deny) {
-            sendUsage(commandSender);
             return false;
         }
 

--- a/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/commands/SleepCommand.java
@@ -56,7 +56,7 @@ public class SleepCommand implements CommandExecutor {
             return true;
         }
 
-        manager.castVote(player.getUniqueId(), accept);
+        boolean requestsMet = manager.castVote(player.getUniqueId(), accept);
         if (accept) {
             Bukkit.broadcastMessage(ChatColor.WHITE + Integer.toString(manager.getRequests()) + "/" +
                     BedSleepManager.getNeededRequests() + " " + ChatColor.GREEN + commandSender.getName() + " has accepted.");
@@ -65,7 +65,10 @@ public class SleepCommand implements CommandExecutor {
                     BedSleepManager.getNeededRequests() + " " + ChatColor.RED + commandSender.getName() + " has denied.");
         }
 
-        manager.checkRequired();
+        if (requestsMet) {
+            Bukkit.broadcastMessage(ChatColor.GOLD + "Requests met!");
+        }
+
         return true;
     }
 }

--- a/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
+++ b/src/main/java/net/minewest/minewestcore/bedutil/listeners/PlayerListener.java
@@ -3,7 +3,6 @@ package net.minewest.minewestcore.bedutil.listeners;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
-import net.minewest.minewestcore.MinewestCorePlugin;
 import net.minewest.minewestcore.bedutil.BedSleepManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -14,6 +13,12 @@ import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerListener implements Listener {
+
+    private BedSleepManager manager;
+
+    public PlayerListener(BedSleepManager manager) {
+        this.manager = manager;
+    }
 
     @EventHandler
     public void onPlayerSleepEvent(PlayerBedEnterEvent event) {
@@ -41,7 +46,6 @@ public class PlayerListener implements Listener {
             player.spigot().sendMessage(c);
         }
 
-        BedSleepManager manager = MinewestCorePlugin.getInstance().getBedSleepManager();
 
         manager.setEnabled(event.getPlayer().getUniqueId());
         event.getPlayer().performCommand("sleep accept");
@@ -49,6 +53,6 @@ public class PlayerListener implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        MinewestCorePlugin.getInstance().getBedSleepManager().updatePlayers();
+        manager.updatePlayers();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MinewestCore
 main: net.minewest.minewestcore.MinewestCorePlugin
 authors: [Taon2, spencrr]
-version: 1.0.7
+version: 1.0.8
 commands:
   sleep:
     description: Accepts or denies a request to sleep.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: MinewestCore
 main: net.minewest.minewestcore.MinewestCorePlugin
 authors: [Taon2, spencrr]
-version: 1.0.6
+version: 1.0.7
 commands:
   sleep:
     description: Accepts or denies a request to sleep.


### PR DESCRIPTION
Removes `getInstance` and `getBedSleepManager` in favor of passing instances to discourage tampering.
Note: `checkRequired` has been edited to return a success boolean and the broadcast for requests met is in `SleepCommand`. This is better because all the broadcasts are separated from the voting logic in the `BedSleepManager`.